### PR TITLE
Added means to add arbitrary ACL rules to the webinterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Role Variables
 * `monit_webinterface_enabled`: Enable monit web interface. Defaults to `true`.
 * `monit_webinterface_bind`: IP address to bind web interface. Defaults to `0.0.0.0` (listen for external requests).
 * `monit_webinterface_port`: Port for web interface. Defaults to `2812`.
-* `monit_webinterface_rw_group`: Define group of users allowed to read and write on web interface. Defaults to `sudo`.
-* `monit_webinterface_r_group`: Define group of users allowed to read on web interface. Defaults to `users`.
+* `monit_webinterface_rw_group`: Define group of users allowed to read and write on web interface. It is only applied when defined and is empty by default.
+* `monit_webinterface_r_group`: Define group of users allowed to read on web interface. It is only applied when defined and is empty by default.
+* `monit_webinterface_acl_rules`: List of ACL rules for the web interface, such as "localhost" or "hauk:password". It is only applied when defined and is empty by default.
 * `monit_apache_rules`: List of monitoring rules for apache service. You should adjust them to your needs.
 * `monit_apache_groups`: List of groups for the apache service. This list is empty by default.
 * `monit_memcached_rules`: List of monitoring rules for memcached service. You should adjust them to your needs.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,6 @@ monit_mail_enabled: false
 monit_webinterface_enabled: true
 monit_webinterface_bind: 0.0.0.0
 monit_webinterface_port: 2812
-monit_webinterface_rw_group: sudo
-monit_webinterface_r_group: users
 
 monit_apache_rules:
  - "if totalcpu > 80% for 3 cycles then alert"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,19 @@
   notify: restart monit
   tags: monit
 
+- name: Add webinterface ACL rules
+  group: name={{ item }} state=present
+  with_items: monit_webinterface_acl_rules
+  when: monit_webinterface_enabled and monit_webinterface_acl_rules is defined
+
 - name: Add RW group
   group: name={{ monit_webinterface_rw_group }} state=present
-  when: monit_webinterface_enabled
+  when: monit_webinterface_enabled and monit_webinterface_rw_group is defined
   tags: monit
 
 - name: Add R group
   group: name={{ monit_webinterface_r_group }} state=present
-  when: monit_webinterface_enabled
+  when: monit_webinterface_enabled and monit_webinterface_r_group is defined
   tags: monit
 
 - name: Setup mail alerts

--- a/templates/webinterface.j2
+++ b/templates/webinterface.j2
@@ -1,8 +1,18 @@
+# {{ ansible_managed }}
 {% if monit_webinterface_enabled %}
 set httpd port {{ monit_webinterface_port }} and
     use address {{ monit_webinterface_bind }}
+{% if monit_webinterface_acl_rules is defined %}
+{% for rule in monit_webinterface_acl_rules %}
+    allow {{ rule }}
+{% endfor %}
+{% endif %}
+{% if monit_webinterface_rw_group is defined %}
     allow @{{ monit_webinterface_rw_group }}
+{% endif %}
+{% if monit_webinterface_r_group is defined %}
     allow @{{ monit_webinterface_r_group }} readonly
+{% endif %}
 {% else %}
 # No Webinterface
 {% endif %}


### PR DESCRIPTION
Hi,

I wanted to **not** have ACL rules for groups (eg, "allow @sudo") for the webinterface and, as it was, the role did not allow me to do that since the defaults include these values. As such, I've removed it from the defaults and change the tasks that create the groups such that they'll only be created when the vars `monit_webinterface_r_group`and `monit_webinterface_rw_group` are defined.

Also, I've had a `monit_webinterface_acl_rules` var, so that we can add ACL rules in the form of "allow IP-ADDRESS" or others.

Thanks
