### PR TITLE
Update example link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Monit
 ========
 
-Ansible role for configuring Monit. Sample usage see [example.yml](example.yml).
+Ansible role for configuring Monit. Sample usage see [example.yml](http://github.com/pgolm/ansible-playbook-monit/blob/master/example.yml).
 
 Requirements
 ------------


### PR DESCRIPTION
The example link was broken when README.md was posted on https://galaxy.ansible.com/list#/roles/322 .
