### PR TITLE
Switch to 0700 for monitrc

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,7 +5,7 @@
     dest: /etc/monit/monitrc
     owner: root
     group: root
-    mode: 0644
+    mode: 0700
   notify: restart monit
 
 - name: config - Setup webinterface


### PR DESCRIPTION
```
NOTIFIED: [pgolm.monit | restart monit] ***************************************
failed: [10.00.33.60] => {"failed": true}
msg: monit: The control file '/etc/monit/monitrc' must have permissions no more than -rwx------ (0700); right now permissions are -rw-r--r-- (0644).
```

When provisioning in:

```
vagrant@vagrant-ubuntu-trusty-64:~$ monit -V
This is Monit version 5.6
Copyright (C) 2001-2013 Tildeslash Ltd. All Rights Reserved.
```
