### PR TITLE
Proper order in mail config

### DIFF
--- a/templates/mail.j2
+++ b/templates/mail.j2
@@ -2,10 +2,11 @@
 
 set mailserver {{ monit_mailserver_host }} port {{ monit_mailserver_port }}
   username "{{ monit_mailserver_user }}" password "{{ monit_mailserver_password }}"
-  with timeout {{ monit_mailserver_timeout | default(5) }} seconds
   {% if monit_mailserver_ssl_version is defined -%}
   using {{ monit_mailserver_ssl_version }}
   {% endif -%}
+  with timeout {{ monit_mailserver_timeout | default(5) }} seconds
+
 
 set alert {{ monit_alert_address }}
 


### PR DESCRIPTION
With previous order Monit was complaining:

```
failed: [10.00.33.60] => {"failed": true}
msg: /etc/monit/conf.d/mail:6: Error: syntax error 'TLSV1'
```

Docs as well suggest this order: https://mmonit.com/monit/documentation/monit.html#Setting-a-mail-server-for-alert-delivery
