### PR TITLE
Force start

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Role Variables
   * `stop`: Command that stop the service. Optional.
   * `rules`: List of rules to be included in this service. Optional.
 * `monit_service_detele_unlisted`: Remove existing service monitorization configurations not declared in the `services`. Defaults to `true`.
+* `monit_start_monitors`: Start configured `services`. Defaults to `true`.
 * `monit_mail_enabled`: Enable mail alerts. Defaults to `false`.
 * `monit_mailserver_host`: Mailserver host address. Defaults to `localhost`.
 * `monit_mailserver_host`: Mailserver host port. Defaults to `25`.
@@ -47,6 +48,10 @@ Role Variables
 * `monit_memcached_rules`: List of monitoring rules for memcached service. You should adjust them to your needs.
 * `monit_memcached_groups`: List of groups for the memcached service. This list is empty by default.
 
+The following variables are used for the logic of the role and should not be changed by the users.
+
+* `monit_unstartable_monitors`: Config files present in `/etc/monit/conf.d` that are not actually monitors and, as such, should no be started by our role when `monit_start_monitors` is true.
+
 Custom facts
 ------------
 
@@ -58,7 +63,7 @@ MIT
 
 CONTRIBUTE
 ----------
-	
+
 Feel free to contribute by add issue and pull request.
 
 CONTRIBUTORS

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ monit_id_file: /var/lib/monit/id
 
 monit_services: []
 monit_service_delete_unlisted: true
+monit_start_monitors: true
 
 monit_mail_enabled: false
 monit_mailserver_host: localhost

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -42,6 +42,6 @@
 - meta: flush_handlers
 
 - name: monitors - Start configured monitors
-  shell: monit start {{ item }}
+  command: monit start {{ item }}
   with_items: ansible_local.monit.monit_configured_services
   when: monit_start_monitors and ansible_local.monit.monit_configured_services is defined and item not in monit_unstartable_monitors

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -39,6 +39,8 @@
   when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
   notify: restart monit
 
+- meta: flush_handlers
+
 - name: monitors - Start configured monitors
   shell: monit start {{ item }}
   with_items: ansible_local.monit.monit_configured_services

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -38,3 +38,8 @@
   with_items: monit_services_present.stdout_lines
   when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
   notify: restart monit
+
+- name: monitors - Start configured monitors
+  shell: monit start {{ item }}
+  with_items: ansible_local.monit.monit_configured_services
+  when: monit_start_monitors and ansible_local.monit.monit_configured_services is defined and item not in monit_unstartable_monitors

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+monit_unstartable_monitors: ['webinterface', 'mail']
+


### PR DESCRIPTION
Hello,

Now we start monitors after running the role. I've found that sometimes the monitors are stopped for some reason and I expect them to be started after running the role. This behaviour can be changed by setting `monit_start_monitors` to `false`. More info on the README.md.

Thanks!
