### PR TITLE
 enable/disable one monit service

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Custom facts
 
 This role writes a `monit_services_configured` on `/etc/ansible/facts.d/monit.fact` in order to keep track of the configured monitors between different plays. This helps us removing unused monitors.
 
+Add Enabled: False to service if you don't want to use it (temporarily, etc...)
 LICENSE
 -------
 MIT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ monit_webinterface_enabled: true
 monit_webinterface_bind: 0.0.0.0
 monit_webinterface_port: 2812
 
+mmonit_address: http://monit:r3gistered@tower.dlabs.si:8080/collector
+
 monit_apache_rules:
  - "if totalcpu > 80% for 3 cycles then alert"
  - "if totalmem > 400.0 MB for 5 cycles then alert"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,9 @@ monit_mailserver_host: localhost
 monit_mailserver_port: 25
 
 monit_webinterface_enabled: true
-monit_webinterface_bind: 0.0.0.0
+
+## uses actual ip if not defined
+#monit_webinterface_bind: 0.0.0.0
 monit_webinterface_port: 2812
 
 mmonit_address: http://monit:r3gistered@tower.dlabs.si:8080/collector

--- a/fork.txt
+++ b/fork.txt
@@ -1,0 +1,4 @@
+original
+https://github.com/pgolm/ansible-playbook-monit
+fork
+https://galaxy.ansible.com/list#/roles/2113

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -6,6 +6,7 @@
     owner: root
     group: root
   with_items: monit_services
+  when: "{{ item.enabled|default('True') }}"
   notify: restart monit
 
 - name: monitors - Create facts directory

--- a/templates/monit.fact.j2
+++ b/templates/monit.fact.j2
@@ -1,7 +1,9 @@
 {
   "monit_configured_services": [
 {% for service in monit_services %}
+{% if service.enabled|default('True') %}
     "{{ service.name }}",
+{% endif %}
 {% endfor %}
 {% if monit_mail_enabled %}
     "mail",

--- a/templates/monitrc.j2
+++ b/templates/monitrc.j2
@@ -4,6 +4,8 @@ set daemon {{ monit_cycle }}
 set logfile {{ monit_log_destination }}
 set statefile {{ monit_state_file }}
 set idfile {{ monit_id_file }}
+set mmonit {{ mmonit_address }}
+
 {% if monit_eventqueue_dir is defined %}
 set eventqueue
   basedir {{ monit_eventqueue_dir | default('/var/lib/monit/events') }}

--- a/templates/webinterface.j2
+++ b/templates/webinterface.j2
@@ -1,7 +1,9 @@
 # {{ ansible_managed }}
 {% if monit_webinterface_enabled %}
 set httpd port {{ monit_webinterface_port }} and
+{% if monit_webinterface_bind is defined %}
     use address {{ monit_webinterface_bind }}
+{% endif %}
 {% if monit_webinterface_acl_rules is defined %}
 {% for rule in monit_webinterface_acl_rules %}
     allow {{ rule }}


### PR DESCRIPTION
we are using templates for n-monit services. It's easier for us to just "selec" (by typing enabled or disabled) to all roles in the template.

So, my solution is, that you can add Enabled: False to just one monit service and ansible will not add it to the project. It will also delete it later if changed from True to False. Default befaviour (if True or nothing specified) is True so it doesn't effect old version - services that are written without Enabled parameter, the role will just presume enabled.
