### PR TITLE
Add some Service-checks and restart Service-method

### DIFF
--- a/templates/monitor.j2
+++ b/templates/monitor.j2
@@ -1,13 +1,30 @@
 {% set monit_monitor = item -%}
 # {{ ansible_managed }}
 
-{% if monit_monitor.type == 'process' or monit_monitor.type == 'process_by_name' %}
-check process {{ monit_monitor.name }}
 {% if monit_monitor.type == 'process' %}
-  pidfile {{ monit_monitor.target }}
+check process {{ monit_monitor.name }} with pidfile {{ monit_monitor.target }}
 {% elif monit_monitor.type == 'process_by_name' %}
-  matching "{{ monit_monitor.target }}"
-{% endif %}
+check process {{ monit_monitor.name }} with matching "{{ monit_monitor.target }}"
+{% elif monit_monitor.type == 'file' %}
+check file {{ monit_monitor.name }} with path {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'fifo' %}
+check fifo {{ monit_monitor.name }} with path {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'filesystem' %}
+check filesystem {{ monit_monitor.name }} with path {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'directory' %}
+check directory {{ monit_monitor.name }} with path {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'host' %}
+check host {{ monit_monitor.name }} with address {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'system' %}
+check system {{ monit_monitor.name }}
+{% elif monit_monitor.type == 'program' %}
+check program {{ monit_monitor.name }} with path {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'network' %}
+check network {{ monit_monitor.name }} with address {{ monit_monitor.target }}
+{% elif monit_monitor.type == 'network_by_interface' %}
+check network {{ monit_monitor.name }} with interface {{ monit_monitor.target }}
+{% endif -%}
+
 {% if monit_monitor.start is defined %}
   start program = "{{ monit_monitor.start }}"
   {%- if monit_monitor.user is defined %} as uid {{monit_monitor.user}}{% endif %}
@@ -19,13 +36,12 @@ check process {{ monit_monitor.name }}
   {%- if monit_monitor.user is defined %} as uid {{monit_monitor.user}}{% endif %}
   {%- if monit_monitor.group is defined %} and gid {{monit_monitor.group}}{% endif %}
 {% endif %}
-{% elif monit_monitor.type == 'system' %}
-check system {{ monit_monitor.name }}
-{% elif monit_monitor.type == 'host' %}
-check host {{ monit_monitor.name }} with address {{ monit_monitor.target }}
-{% elif monit_monitor.type == 'filesystem' %}
-check filesystem {{ monit_monitor.name }} with path {{ monit_monitor.target }}
-{% endif -%}
+
+{% if monit_monitor.restart is defined %}
+  restart program = "{{ monit_monitor.restart }}"
+  {%- if monit_monitor.user is defined %} as uid {{monit_monitor.user}}{% endif %}
+  {%- if monit_monitor.group is defined %} and gid {{monit_monitor.group}}{% endif %}
+{% endif %}
 
 {% if monit_monitor.rules is defined %}
 {% for rule in monit_monitor.rules %}

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -17,9 +17,30 @@
         target: /var/run/apache2.pid
         start: /usr/sbin/service apache2 start
         stop: /usr/sbin/service apache2 stop
+        restart: /usr/sbin/service apache2 restart
         rules:
           - "if failed port 80 protocol http then restart"
           - "if 5 restarts within 5 cycles then timeout"
+      - name: my_file
+        type: file
+        target: /tmp/foo.bar
+        rules:
+          - "if changed timestamp then exec \"/bin/bash -c 'echo `data` >> /tmp/foo.bar.changed'\""
+      - name: my_filesystem
+        type: filesystem
+        target: /dev/sda1
+        rules:
+          - "if space usage > 80% for 5 times within 15 cycles then alert"
+      - name: my_directory
+        type: directory
+        target: /foo
+        rules:
+          - "if timestamp < 1 hour then alert"
+      - name: google
+        type: host
+        target: google.com
+        rules:
+          - "if failed port 443 type tcpSSL protocol http then alert"
       - name: localhost
         type: system
         rules:
@@ -29,11 +50,11 @@
           - "if cpu usage (user) > 70% for 8 cycles then alert"
           - "if cpu usage (system) > 40% for 8 cycles then alert"
           - "if cpu usage (wait) > 20%  for 8 cycles then alert"
-      - name: google
-        type: host
-        target: google.com
+      - name: my_network
+        type: network
+        target: 127.0.0.1
         rules:
-          - "if failed port 443 type tcpSSL protocol http then alert"
+          - "if saturation > 90% then alert"
     monit_webinterface_enabled: true
     monit_webinterface_acl_rules:
       - "localhost"


### PR DESCRIPTION
Hi

I add some Service-checks [ref](https://mmonit.com/monit/documentation/monit.html#Service-checks)

And I add restart Service-method, and enable start, stop and restart Service-methods for all services, because  [ref](https://mmonit.com/monit/documentation/monit.html#SERVICE-METHODS)

> Each service can have associated start, stop and restart methods which Monit can use to execute action on the service.

Please review it. thanks.
