### PR TITLE
fix Write monitors bug for ansible 2.2.0.0

### DIFF
--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -5,7 +5,7 @@
     dest: "{{ monit_includes }}/{{ item.name }}"
     owner: root
     group: root
-  with_items: monit_services
+  with_items: "{{ monit_services }}"
   notify: restart monit
 
 - name: monitors - Create facts directory
@@ -35,6 +35,6 @@
   file:
     path: "{{ monit_includes }}/{{ item }}"
     state: absent
-  with_items: monit_services_present.stdout_lines
+  with_items: "{{ monit_services_present.stdout_lines }}"
   when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
   notify: restart monit


### PR DESCRIPTION
Ansible: 2.2.0.0

Hi, `with_items: monit_services` not working for ansible 2.2.0.0 , I fixed it, please review and merge, thanks.

This is the exception messages
```
TASK [pgolm.monit : monitors - Write monitors] *********************************
fatal: [app]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'name'\n\nThe error appears to have been in '/path/ansible/roles/pgolm.monit/tasks/monitors.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: monitors - Write monitors\n  ^ here\n"}
```