### PR TITLE
Update monitors.yml

### DIFF
--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -35,6 +35,6 @@
   file:
     path: "{{ monit_includes }}/{{ item }}"
     state: absent
-  with_items: "{{ monit_services_present.stdout_lines }}"
+  with_items: "{{ monit_services_present.stdout_lines | default([]) }}"
   when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
   notify: restart monit


### PR DESCRIPTION
Add with_items default value empty list.

I have got a problem with ansible 2.2.0.0, because ansible evaluate "with_items" before apply "when" condition.

```
fatal: [xxxx]: FAILED! => {
    "failed": true,
    "msg": "'dict object' has no attribute 'stdout_lines'"
}
```

I try to use role in my-playbook/meta/main.yaml
```
dependencies:
   - { role: pgolm.monit, when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int <= 6}
```

