### PR TITLE
Freebsd support with improved perms

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ monit_id_file: "{{ monit_lib_folder }}/id"
 
 monit_services: []
 monit_service_delete_unlisted: true
+monit_service_enabled: false
 
 monit_mail_enabled: false
 monit_mailserver_host: localhost

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
   - name: EL
     versions:
     - all
+  - name: FreeBSD
+    versions:
+    - all
   - name: RedHat
     version:
     - all

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,6 +2,9 @@
 - include_vars: debian.yml
   when:  ansible_os_family == "Debian"
 
+- include_vars: freebsd.yml
+  when:  ansible_os_family == "FreeBSD"
+
 - include_vars: redhat.yml
   when: ansible_os_family == "RedHat"
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,35 +9,35 @@
   when: ansible_os_family == "RedHat"
 
 - name: create includes folder
-  file: path={{ monit_includes }} state=directory mode=0600
+  file: path={{ monit_includes }} state=directory mode=0640 owner="{{ monit_owner }}" group="{{ monit_group }}"
 
 - name: create lib folder
-  file: path="{{ monit_lib_folder }}" state=directory mode=0600
+  file: path="{{ monit_lib_folder }}" state=directory mode=0640 owner="{{ monit_owner }}" group="{{ monit_group }}"
   
 - name: config - Setup monitrc
   template:
     src: monitrc.j2
     dest: "{{monitrc_conf}}"
-    owner: root
-    group: root
-    mode: 0700
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0600
   notify: restart monit
 
 - name: config - Setup webinterface
   template:
     src: webinterface.j2
     dest: "{{ monit_includes }}/webinterface"
-    owner: root
-    group: root
-    mode: 0644
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0640
   notify: restart monit
 
 - name: config - Setup mail alerts
   template:
     src: mail.j2
     dest: "{{ monit_includes }}/mail"
-    owner: root
-    group: root
-    mode: 0644
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0640
   notify: restart monit
   when: monit_mail_enabled

--- a/tasks/freebsd/pkg.yml
+++ b/tasks/freebsd/pkg.yml
@@ -1,0 +1,5 @@
+---
+- name: pkg - Install package
+  pkgng:
+    name: monit
+    state: present

--- a/tasks/mail.yml
+++ b/tasks/mail.yml
@@ -3,8 +3,8 @@
   template:
     src: mail.j2
     dest: {{ monit_includes }}/mail
-    owner: root
-    group: root
-    mode: 0644
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0640
   notify: restart monit
   when: monit_mail_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,10 @@
   tags: monit_pkg
   when: ansible_os_family == "Debian"
 
+- include: freebsd/pkg.yml
+  tags: monit_pkg
+  when: ansible_os_family == "FreeBSD"
+
 - include: redhat/pkg.yml
   tags: monit_pkg
   when: ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,7 @@
 
 - include: monitors.yml
   tags: monit_monitors
+
+- name: ensure monit is active and running
+  service: name=monit state=started enabled=yes
+  when: monit_service_enabled

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -38,6 +38,6 @@
   file:
     path: "{{ monit_includes }}/{{ item }}"
     state: absent
-  with_items: "{{ monit_services_present.stdout_lines }}"
-  when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
+  with_items: "{{ monit_services_present.stdout_lines | difference(ansible_local.monit.monit_configured_services) }}"
+  when: monit_service_delete_unlisted
   notify: restart monit

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -3,8 +3,9 @@
   template:
     src: monitor.j2
     dest: "{{ monit_includes }}/{{ item.name }}"
-    owner: root
-    group: root
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0640
   with_items: "{{ monit_services }}"
   notify: restart monit
 
@@ -12,6 +13,8 @@
   file:
     path: "/etc/ansible/facts.d"
     mode: 0755
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
     state: directory
 
 - name: monitors - Registers configured monitors

--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -11,7 +11,7 @@
 
 - name: monitors - Create facts directory
   file:
-    path: "/etc/ansible/facts.d"
+    path: "{{ monit_factsd }}"
     mode: 0755
     owner: "{{ monit_owner }}"
     group: "{{ monit_group }}"
@@ -20,7 +20,7 @@
 - name: monitors - Registers configured monitors
   template:
     src: "monit.fact.j2"
-    dest: "/etc/ansible/facts.d/monit.fact"
+    dest: "{{ monit_factsd }}/monit.fact"
     mode: 0644
   register: monit_write_facts
 

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -3,6 +3,7 @@
   template:
     src: webinterface.j2
     dest: "{{ monit_includes }}/webinterface"
-    owner: root
-    group: root
+    owner: "{{ monit_owner }}"
+    group: "{{ monit_group }}"
+    mode: 0640
   notify: restart monit

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,3 +1,5 @@
 ---
 monitrc_conf: /etc/monit/monitrc
 monit_includes: /etc/monit/conf.d
+monit_owner: root
+monit_group: root

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,5 +1,6 @@
 ---
 monitrc_conf: /etc/monit/monitrc
 monit_includes: /etc/monit/conf.d
+monit_factsd: /etc/ansible/facts.d
 monit_owner: root
 monit_group: root

--- a/vars/freebsd.yml
+++ b/vars/freebsd.yml
@@ -1,3 +1,5 @@
 ---
 monitrc_conf: /usr/local/etc/monitrc
 monit_includes: /usr/local/etc/monit.d
+monit_owner: root
+monit_group: wheel

--- a/vars/freebsd.yml
+++ b/vars/freebsd.yml
@@ -1,0 +1,3 @@
+---
+monitrc_conf: /usr/local/etc/monitrc
+monit_includes: /usr/local/etc/monit.d

--- a/vars/freebsd.yml
+++ b/vars/freebsd.yml
@@ -1,5 +1,6 @@
 ---
 monitrc_conf: /usr/local/etc/monitrc
 monit_includes: /usr/local/etc/monit.d
+monit_factsd: /usr/local/etc/ansible/facts.d
 monit_owner: root
 monit_group: wheel

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,5 +1,6 @@
 ---
 monitrc_conf: /etc/monitrc
 monit_includes: /etc/monit.d
+monit_factsd: /etc/ansible/facts.d
 monit_owner: root
 monit_group: root

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,5 @@
 ---
 monitrc_conf: /etc/monitrc
 monit_includes: /etc/monit.d
+monit_owner: root
+monit_group: root


### PR DESCRIPTION
This PR improves upon a number of items:

1. Adds `FreeBSD` support, with `Monit` installed from the Ports Collection.
2. Improves security of all files and directories created; by removing other user access.
3. Adds a flag to start and enable `Monit`, as a service. This is disabled by default, to maintain previous functionality while also realizing that `Monit` is sometimes ran via `inittab`.
4. Switches to the use of a Jinja2 filter for list differences between the current monitors and the actual monitors found.