### PR TITLE
Add default value for monit_services_present

### DIFF
--- a/tasks/monitors.yml
+++ b/tasks/monitors.yml
@@ -35,6 +35,6 @@
   file:
     path: "{{ monit_includes }}/{{ item }}"
     state: absent
-  with_items: "{{ monit_services_present.stdout_lines }}"
+  with_items: "{{ monit_services_present.stdout_lines | default([]) }}"
   when: monit_service_delete_unlisted and item|basename not in ansible_local.monit.monit_configured_services
   notify: restart monit


### PR DESCRIPTION
Specially useful when running the role on check_mode, otherwise it will throw an error.