### PR TITLE
remove legacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ Role Variables
 * `monit_webinterface_rw_group`: Define group of users allowed to read and write on web interface. It is only applied when defined and is empty by default.
 * `monit_webinterface_r_group`: Define group of users allowed to read on web interface. It is only applied when defined and is empty by default.
 * `monit_webinterface_acl_rules`: List of ACL rules for the web interface, such as "localhost" or "hauk:password". It is only applied when defined and is empty by default. You should probably define at least one for the httpd service to start.
-* `monit_apache_rules`: List of monitoring rules for apache service. You should adjust them to your needs.
-* `monit_apache_groups`: List of groups for the apache service. This list is empty by default.
-* `monit_memcached_rules`: List of monitoring rules for memcached service. You should adjust them to your needs.
-* `monit_memcached_groups`: List of groups for the memcached service. This list is empty by default.
 
 Custom facts
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,13 +14,3 @@ monit_mailserver_port: 25
 monit_webinterface_enabled: true
 monit_webinterface_bind: 0.0.0.0
 monit_webinterface_port: 2812
-
-monit_apache_rules:
- - "if totalcpu > 80% for 3 cycles then alert"
- - "if totalmem > 400.0 MB for 5 cycles then alert"
- - "if children > 250 then alert"
- - "if loadavg(5min) > 20 for 8 cycles then alert"
-
-monit_memcached_rules:
- - "if failed host 127.0.0.1 port 11211 protocol MEMCACHE then restart"
- - "if cpu > 80% for 3 cycles then alert"


### PR DESCRIPTION
Some monitors where introduced into previous PR #4 and #5. They were removed into PR #10. Still, some settings and documentation are remaining.
This PR, remove the legacy, now unused, settings from documentation and defaults.