### PR TITLE
Adding mode argument to monit services

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Role Variables
   * `target`: Target of monitorization. Should be a pidfile, processname, an address or undefined, depending on the `type` of service.
   * `start`: Command that starts the service. Optional.
   * `stop`: Command that stop the service. Optional.
+  * `mode`: Monitoring mode, default is `active`. If `passive` is set no actio nwill be taken in case of fail, only alerts. Optional.
   * `user`: Linux username of the user starting the program. Optional.
   * `group`: Linux group of the user starting the program. Optional.
   * `rules`: List of rules to be included in this service. Optional.

--- a/templates/monitor.j2
+++ b/templates/monitor.j2
@@ -43,6 +43,12 @@ check network {{ monit_monitor.name }} with interface {{ monit_monitor.target }}
   {%- if monit_monitor.group is defined %} and gid {{monit_monitor.group}}{% endif %}
 {% endif %}
 
+{% if monit_monitor.mode is defined %}
+  mode {{ monit_monitor.mode }}
+  {%- if monit_monitor.user is defined %} as uid {{monit_monitor.user}}{% endif %}
+  {%- if monit_monitor.group is defined %} and gid {{monit_monitor.group}}{% endif %}
+{% endif %}
+
 {% if monit_monitor.rules is defined %}
 {% for rule in monit_monitor.rules %}
   {{ rule }}

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -18,6 +18,7 @@
         start: /usr/sbin/service apache2 start
         stop: /usr/sbin/service apache2 stop
         restart: /usr/sbin/service apache2 restart
+        mode: passive
         rules:
           - "if failed port 80 protocol http then restart"
           - "if 5 restarts within 5 cycles then timeout"


### PR DESCRIPTION
Many times we may need to "disable" a monit service to take start/stop actions and only alert in the status of the service.
For this, Monit offer the possibility of setting a service in [passive mode](https://mmonit.com/monit/documentation/monit.html#SERVICE-MONITORING-MODE).

This PR add the mode argument to the template and set one service in the vagrant.yml playbook for testing purposes.