### PR TITLE
Add unixsocket support for webinterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Role Variables
 * `monit_webinterface_enabled`: Enable monit web interface. Defaults to `true`.
 * `monit_webinterface_bind`: IP address to bind web interface. Defaults to `0.0.0.0` (listen for external requests).
 * `monit_webinterface_port`: Port for web interface. Defaults to `2812`.
+* `monit_webinterface_socket_path`: Path to the socket file. If set this, use the unix socket instead of TCP for web interface. Defaults to undefined.
+* `monit_webinterface_socket_owner`: Owner of the socket file. Defaults to undefined.
+* `monit_webinterface_socket_group`: Owner group of the socket file. Defaults to undefined.
+* `monit_webinterface_socket_mode`: Permission of the socket file. Defaults to undefined.
 * `monit_webinterface_rw_group`: Define group of users allowed to read and write on web interface. It is only applied when defined and is empty by default.
 * `monit_webinterface_r_group`: Define group of users allowed to read on web interface. It is only applied when defined and is empty by default.
 * `monit_webinterface_acl_rules`: List of ACL rules for the web interface, such as "localhost" or "hauk:password". It is only applied when defined and is empty by default. You should probably define at least one for the httpd service to start.

--- a/templates/webinterface.j2
+++ b/templates/webinterface.j2
@@ -1,8 +1,21 @@
 # {{ ansible_managed }}
 {% if monit_webinterface_enabled %}
 set httpd
-  port {{ monit_webinterface_port }}
-  use address {{ monit_webinterface_bind }}
+{% if monit_webinterface_socket_path is not defined %}
+    port {{ monit_webinterface_port }}
+    use address {{ monit_webinterface_bind }}
+{% else %}
+    unixsocket {{ monit_webinterface_socket_path }}
+{% if monit_webinterface_socket_owner is defined %}
+    uid {{ monit_webinterface_socket_owner }}
+{% endif %}
+{% if monit_webinterface_socket_group is defined %}
+    gid {{ monit_webinterface_socket_group }}
+{% endif %}
+{% if monit_webinterface_socket_mode is defined %}
+    permission {{ monit_webinterface_socket_mode }}
+{% endif %}
+{% endif %}
 {% if monit_webinterface_acl_rules is defined %}
 {% for rule in monit_webinterface_acl_rules %}
     allow {{ rule }}


### PR DESCRIPTION
Add [unixsocket](https://mmonit.com/monit/documentation/monit.html#UNIX-SOCKET) support for webinterface.
In environments where TCP port cannot be used for security reasons, Unix Socket support is required.

> Note that if HTTP support is disabled, the Monit CLI interface will have reduced functionality, as most CLI commands (such as "monit status") needs to communicate with the Monit background process via the HTTP interface. We strongly recommend having HTTP support enabled. If security is a concern, bind the HTTP interface to local host only or use Unix Socket so Monit is not accessible from the outside.